### PR TITLE
Add Heroku button to make agent setup almost 1-click

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-agent: buildkite-agent start --bootstrap-script /app/bootstrap.sh --build-path /app/builds --hooks-path /app/hooks
+agent: ./buildkite-agent start --bootstrap-script ./bootstrap.sh --build-path ./builds --hooks-path ./hooks

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ This embeds buildkite-agent version 1.0-beta.30.516. To update simply extract th
 
 ## Usage
 
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
+Press the button above, provide your agent token, then hit "Deploy". Once it's
+deployed, click on "Manage App" and scale up the `agent` process to at least 1.
+
+You should see your Buildkite agent dashboard register the new agent.
+
+To set it up on Heroku manually without the button, follow these instructions instead:
+
 ```bash
 # Create a dyno
 $ heroku create my-buildkite-agent \

--- a/app.json
+++ b/app.json
@@ -1,0 +1,23 @@
+{
+  "name": "Buildkite Agent",
+  "website": "https://buildkite.com",
+  "description": "Run Buildkite workers as a Heroku app",
+  "repository": "https://github.com/bjeanes/heroku-buildkite-agent",
+  "logo": "https://logo.clearbit.com/buildkite.com",
+  "keywords": ["buildkite", "ci", "tests", "continuous integration"],
+  "env": {
+    "BUILDKITE_AGENT_TOKEN": {
+      "description": "Get from https://buildkite.com/organizations/YOUR_ORG/agents",
+      "required": true
+    },
+    "BUILDKITE_AGENT_META_DATA": {
+      "description": "Metadata to apply to all builds on this agent. See https://buildkite.com/docs/agent/agent-meta-data",
+      "required": false
+    }
+  },
+  "buildpacks": [
+    {
+      "url": "https://github.com/ryandotsmith/null-buildpack.git"
+    }
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "Buildkite Agent",
   "website": "https://buildkite.com",
   "description": "Run Buildkite workers as a Heroku app",
-  "repository": "https://github.com/bjeanes/heroku-buildkite-agent",
+  "repository": "https://github.com/buildkite/heroku-buildkite-agent",
   "logo": "https://logo.clearbit.com/buildkite.com",
   "keywords": ["buildkite", "ci", "tests", "continuous integration"],
   "env": {

--- a/app.json
+++ b/app.json
@@ -10,6 +10,11 @@
       "description": "Get from https://buildkite.com/organizations/YOUR_ORG/agents",
       "required": true
     },
+    "BUILDKITE_AGENT_NAME": {
+      "description": "Custom agent name",
+      "value": "heroku-%n",
+      "required": false
+    },
     "BUILDKITE_AGENT_META_DATA": {
       "description": "Metadata to apply to all builds on this agent. See https://buildkite.com/docs/agent/agent-meta-data",
       "required": false

--- a/app.json
+++ b/app.json
@@ -18,11 +18,20 @@
     "BUILDKITE_AGENT_META_DATA": {
       "description": "Metadata to apply to all builds on this agent. See https://buildkite.com/docs/agent/agent-meta-data",
       "required": false
+    },
+    "GITHUB_AUTH_TOKEN": {
+      "description": "Used to access private GitHub repos cloned with HTTPS. See http://developer.github.com/v3/oauth/#non-web-application-flow",
+      "required": false
+    },
+    "SSH_KEY": {
+      "description": "Private SSH key for keypair used to fetch repositories, if needed",
+      "required": false
     }
   },
   "buildpacks": [
-    {
-      "url": "https://github.com/ryandotsmith/null-buildpack.git"
-    }
+    { "url": "https://github.com/bjeanes/ssh-private-key-buildpack.git" },
+    { "url": "https://github.com/bjeanes/heroku-buildpack-github-netrc.git" },
+    { "url": "https://github.com/bjeanes/heroku-buildpack-copy-build-creds.git" },
+    { "url": "https://github.com/ryandotsmith/null-buildpack.git" }
   ]
 }


### PR DESCRIPTION
This adds the following button to the `README`:

[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)

It also adds an [`app.json`](https://devcenter.heroku.com/articles/app-json-schema) to allow Heroku to automatically configure the app and prompt for the agent token.

@keithpitt @toolmantim If you like the look of this, you can add the button into the Agents tab on Buildkite.com and [add the `?template=` parameter](https://devcenter.heroku.com/articles/heroku-button#adding-an-explicit-parameter) pointing to the repo (clicking from the `README` works via the referer). Better yet, [add `?env[BUILDKITE_AGENT_TOKEN]=TOKEN`](https://devcenter.heroku.com/articles/heroku-button#parametrizing-buttons) so that the token is already filled in and they just have to confirm the deploy:

![create a new app heroku 2015-09-07 18-18-44](https://cloud.githubusercontent.com/assets/2560/9712279/f4a93144-558c-11e5-9fbe-4bd93906dbb0.png)

Lastly, once these buttons are deployed a few times, this will automatically start showing up on on https://elements.heroku.com/buttons which can potentially act as a new customer channel.

Let me know if you have any questions!
